### PR TITLE
Patch wincred getter

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -42,20 +42,20 @@ URLencode <- function(URL) {
 }
 
 get_encoding_opt <- function() {
-  encoding <- tolower(getOption('keyring.encoding.windows'))
-  if (length(encoding) == 0) encoding = 'auto'
+  opt_encoding <- tolower(getOption('keyring.encoding.windows'))
+  if (length(opt_encoding) == 0) opt_encoding = 'auto'
   env_encoding <- tolower(Sys.getenv("KEYRING_ENCODING_WINDOWS"))
   if (env_encoding == '') env_encoding = 'auto'
   # Handle differing values if both are not auto -- stop in this case
-  if (encoding != env_encoding & !(encoding == 'auto' | env_encoding == 'auto')) {
+  if (opt_encoding != env_encoding & !(opt_encoding == 'auto' & env_encoding == 'auto')) {
     message(sprintf("Sys.getenv('KEYRING_ENCODING_WINDOWS'):\t'%s'", env_encoding))
-    message(sprintf("getOption(keyring.encoding.windows):\t'%s'", encoding))
+    message(sprintf("getOption(keyring.encoding.windows):\t'%s'", opt_encoding))
     stop("Mismatch in keyring encoding settings; value set with both an environment variable and R option.\nChange environment variable with Sys.setenv('KEYRING_ENCODING_WINDOWS' = 'encoding_type'),\nand R option with options(keyring.encoding.windows = 'encoding_type') to match.")
   }
   # If one and only one is auto, then one of these was set deliberately; respect this
-  if (xor(encoding == 'auto', env_encoding == 'auto')) {
+  if (xor(opt_encoding == 'auto', env_encoding == 'auto')) {
     # Encoding is whichever one that is not auto.
-    encodings <- c(encoding, env_encoding)
+    encodings <- c(opt_encoding, env_encoding)
     encoding  <- encodings[ encodings != 'auto' ]
   }
   # Confirm valid encoding. Suggest closest match if not found.

--- a/R/utils.R
+++ b/R/utils.R
@@ -46,8 +46,8 @@ get_encoding_opt <- function() {
   if (length(opt_encoding) == 0) opt_encoding = 'auto'
   env_encoding <- tolower(Sys.getenv("KEYRING_ENCODING_WINDOWS"))
   if (env_encoding == '') env_encoding = 'auto'
-  # Handle differing values if both are not auto -- stop in this case
-  if (opt_encoding != env_encoding & !(opt_encoding == 'auto' & env_encoding == 'auto')) {
+  # Handle differing values if one or the other is not auto -- stop in this case
+  if (opt_encoding != env_encoding & !(opt_encoding == 'auto' | env_encoding == 'auto')) {
     message(sprintf("Sys.getenv('KEYRING_ENCODING_WINDOWS'):\t'%s'", env_encoding))
     message(sprintf("getOption(keyring.encoding.windows):\t'%s'", opt_encoding))
     stop("Mismatch in keyring encoding settings; value set with both an environment variable and R option.\nChange environment variable with Sys.setenv('KEYRING_ENCODING_WINDOWS' = 'encoding_type'),\nand R option with options(keyring.encoding.windows = 'encoding_type') to match.")
@@ -57,6 +57,16 @@ get_encoding_opt <- function() {
     # Encoding is whichever one that is not auto.
     encodings <- c(opt_encoding, env_encoding)
     encoding  <- encodings[ encodings != 'auto' ]
+  }
+  # If both the same:
+  if (opt_encoding == env_encoding) {
+    # And they're auto, then auto
+    if (opt_encoding == 'auto') {
+      encoding = 'auto'
+    } else {
+      # Otherwise, the encoding is either one
+      encoding = opt_encoding
+    }
   }
   # Confirm valid encoding. Suggest closest match if not found.
   if (encoding != 'auto' & !(encoding %in% tolower(iconvlist()))) {

--- a/tests/testthat/test-python-compatibility.R
+++ b/tests/testthat/test-python-compatibility.R
@@ -3,10 +3,66 @@
 library(reticulate)
 library(keyring)
 
-reticulate::use_condaenv('keyring', required = TRUE)
-pyring <- reticulate::import('keyring')
+context("Testing encoding retrieval function")
+
+test_that("No option/env var set returns auto", {
+  encoding = get_encoding_opt()
+  expect_equal(encoding, 'auto')
+})
+
+test_that("Option encoding set and env unset returns option encoding", {
+  options(keyring.encoding.windows = 'utf-16le')
+  encoding = get_encoding_opt()
+  expect_equal(encoding, 'utf-16le')
+  options(keyring.encoding.windows = NULL)
+})
+
+test_that("Option encoding unset and env set returns env encoding", {
+  Sys.setenv("KEYRING_ENCODING_WINDOWS" = 'utf-8')
+  encoding = get_encoding_opt()
+  expect_equal(encoding, 'utf-8')
+  Sys.setenv("KEYRING_ENCODING_WINDOWS" = '')
+})
+
+test_that("Option encoding set and env var set and EQUAL returns expected value", {
+  options(keyring.encoding.windows = 'utf-16le')
+  Sys.setenv("KEYRING_ENCODING_WINDOWS" = 'utf-16le')
+  encoding = get_encoding_opt()
+  expect_equal(encoding, 'utf-16le')
+  options(keyring.encoding.windows = NULL)
+  Sys.setenv("KEYRING_ENCODING_WINDOWS" = '')
+})
+
+test_that("Invalid encoding (not in iconvlist) returns error", {
+  options(keyring.encoding.windows = 'Omicron Persei 8')
+  Sys.setenv("KEYRING_ENCODING_WINDOWS" = 'Omicron Persei 8')
+  expect_error(get_encoding_opt())
+  options(keyring.encoding.windows = NULL)
+  Sys.setenv("KEYRING_ENCODING_WINDOWS" = '')
+})
+
+test_that("iconv suggestion works as expected", {
+  options(keyring.encoding.windows = 'utf-16lp')
+  expect_message(
+    object = expect_error(get_encoding_opt()),
+    regexp = "Encoding not found in iconvlist(). Did you mean UTF-16LE?",
+    fixed = TRUE
+  )
+  options(keyring.encoding.windows = NULL)
+})
+
+test_that("Having two different encodings set between opt and env return error", {
+  options(keyring.encoding.windows = 'x_Chinese-Eten')
+  Sys.setenv("KEYRING_ENCODING_WINDOWS" = 'latin9')
+  expect_error(get_encoding_opt())
+  options(keyring.encoding.windows = NULL)
+  Sys.setenv("KEYRING_ENCODING_WINDOWS" = '')
+})
 
 context("Testing compatibility with python keyring package")
+
+reticulate::use_condaenv('keyring', required = TRUE)
+pyring <- reticulate::import('keyring')
 
 test_that("Setting key with R cannot be read using python under default settings (encoding mismatches)", {
   # Set with R, default settings


### PR DESCRIPTION
* Update variable names in `get_encoding_opt` (`encoding -> opt_encoding`) for clarity.
* Fix logic when both settings are the same and *not* auto.