### PR TITLE
Patch wincred setter

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,7 @@ License: MIT + file LICENSE
 LazyData: true
 URL: https://github.com/r-lib/keyring#readme
 BugReports: https://github.com/r-lib/keyring/issues
-RoxygenNote: 6.1.1
+RoxygenNote: 7.1.0
 Roxygen: list(markdown = TRUE)
 Imports:
     assertthat,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,7 +32,8 @@ Suggests:
     covr,
     mockery,
     testthat,
-    withr
+    withr,
+    reticulate
 Encoding: UTF-8
 SystemRequirements: Optional: libsecret on Linux (libsecret-1-dev on
     Debian/Ubuntu, libsecret-devel on Fedora/CentOS)

--- a/R/api.R
+++ b/R/api.R
@@ -29,8 +29,8 @@
 #'
 #' ## Encoding
 #'
-#' If required, an encoding can be specified using either an R option
-#' (\code{keyring.encoding.windows}) or environment variable
+#' On Windows, if required, an encoding can be specified using either an R
+#' option (\code{keyring.encoding.windows}) or environment variable
 #' (\code{KEYRING_ENCODING_WINDOWS}). These will be applied when both getting
 #' and setting keys. To set, use one of:
 #'

--- a/R/api.R
+++ b/R/api.R
@@ -45,8 +45,14 @@
 #' \code{Sys.setenv("KEYRING_ENCODING_WINDOWS" = '')}
 #'
 #' This is reserved primarily for compatibility with keys set with other
-#' software, such as Python's implementation of keyring. For a list of valid
-#' encodings, use \code{iconvlist()}.
+#' software, such as Python's implementation of keyring. For a list of
+#' encodings, use \code{iconvlist()}, although it should be noted that not
+#' _every_ encoding can be properly converted, even for trivial cases. These may
+#' include CP-GR, CP-IS, cp1025, CP1125, CP1133, CP154, CP367, CP819, CP853,
+#' CSPTCP154, CYRILLIC-ASIAN, EUC-CN, EUCCN, hz-gb-2312, IBM-CP1133,
+#' iso-2022-kr, iso2022-kr, PT154, PTCP154, x-cp50227, x-Europa, x-iscii-as,
+#' x-iscii-be, x-iscii-de, x-iscii-gu, x-iscii-ka, x-iscii-ma, x-iscii-or,
+#' x-iscii-pa, x-iscii-ta, and x-iscii-te.
 #'
 #' @param service Service name, a character scalar.
 #' @param username Username, a character scalar, or `NULL` if the key

--- a/R/api.R
+++ b/R/api.R
@@ -27,6 +27,27 @@
 #' `key_list` lists all keys of a keyring, or the keys for a certain
 #' service (if `service` is not `NULL`).
 #'
+#' ## Encoding
+#'
+#' If required, an encoding can be specified using either an R option
+#' (\code{keyring.encoding.windows}) or environment variable
+#' (\code{KEYRING_ENCODING_WINDOWS}). These will be applied when both getting
+#' and setting keys. To set, use one of:
+#'
+#' \code{options(keyring.encoding.windows = 'encoding-type')}
+#'
+#' \code{Sys.setenv("KEYRING_ENCODING_WINDOWS" = 'encoding-type')}
+#'
+#' To reset these values, restart your R session or use:
+#'
+#' \code{options(keyring.encoding.windows = NULL)}
+#'
+#' \code{Sys.setenv("KEYRING_ENCODING_WINDOWS" = '')}
+#'
+#' This is reserved primarily for compatibility with keys set with other
+#' software, such as Python's implementation of keyring. For a list of valid
+#' encodings, use \code{iconvlist()}.
+#'
 #' @param service Service name, a character scalar.
 #' @param username Username, a character scalar, or `NULL` if the key
 #'   is not associated with a username.
@@ -65,7 +86,7 @@
 #' kr_name <- "my_keyring"
 #' kr_service <- "my_database"
 #' kr_username <- "my_username"
-#' 
+#'
 #' ## Create a keyring and add an entry using the variables above
 #' kb <- keyring::backend_file$new()
 #' ## Prompt for the keyring password, used to unlock keyring
@@ -74,9 +95,9 @@
 #' kb$set(kr_service, username=kr_username, keyring=kr_name)
 #' # Lock the keyring
 #' kb$keyring_lock(kr_name)
-#' 
+#'
 #' ## The keyring file is stored at ~/.config/r-keyring/ on Linux
-#' 
+#'
 #' ## Output the stored password
 #' keyring::backend_file$new()$get(service = kr_service,
 #'   user = kr_username,

--- a/R/backend-wincred.R
+++ b/R/backend-wincred.R
@@ -337,12 +337,12 @@ b_wincred_set_with_raw_value <- function(self, private, service,
   keyring <- keyring %||% private$keyring
   target <- b_wincred_target(keyring, service, username)
   encoding <- get_encoding_opt()
+  if (encoding != 'auto') {
+    password = iconv(x = password, from = '', to = encoding, toRaw = TRUE)[[1]]
+  } else {
+    password = charToRaw(password)
+  }
   if (is.null(keyring)) {
-    if (encoding != 'auto') {
-      password = iconv(x = password, from = '', to = encoding, toRaw = TRUE)[[1]]
-    } else {
-      password = charToRaw(password)
-    }
     b_wincred_i_set(target, password, username = username)
     return(invisible(self))
   }

--- a/R/backend-wincred.R
+++ b/R/backend-wincred.R
@@ -303,8 +303,7 @@ b_wincred_set <- function(self, private, service, username, keyring) {
 
 b_wincred_set_with_value <- function(self, private, service,
                                      username, password, keyring) {
-  b_wincred_set_with_raw_value(self, private, service, username,
-                               charToRaw(password), keyring)
+  b_wincred_set_with_raw_value(self, private, service, username, password, keyring)
 }
 
 #' Set a key on a Wincred keyring
@@ -337,11 +336,16 @@ b_wincred_set_with_raw_value <- function(self, private, service,
 
   keyring <- keyring %||% private$keyring
   target <- b_wincred_target(keyring, service, username)
+  encoding <- get_encoding_opt()
   if (is.null(keyring)) {
+    if (encoding != 'auto') {
+      password = iconv(x = password, from = '', to = encoding, toRaw = TRUE)[[1]]
+    } else {
+      password = charToRaw(password)
+    }
     b_wincred_i_set(target, password, username = username)
     return(invisible(self))
   }
-
   ## Not the default keyring, we need to encrypt it
   target_keyring <- b_wincred_target_keyring(keyring)
   aes <- b_wincred_unlock_keyring_internal(keyring)

--- a/R/backend-wincred.R
+++ b/R/backend-wincred.R
@@ -321,10 +321,20 @@ b_wincred_set_with_value <- function(self, private, service,
 #' 6. If yes, unlock it.
 #' 7. Encrypt the key with the AES key, and store it.
 #'
+#' If required, an encoding can be specified using either an R option
+#' (\code{keyring.encoding.windows}) or environment variable
+#' (\code{KEYRING_ENCODING_WINDOWS}). To set, use one of:
+#'
+#' \code{options(keyring.encoding.windows = 'encoding-type')}
+#' \code{Sys.setenv("KEYRING_ENCODING_WINDOWS" = 'encoding-type')}
+#'
+#' For a list of valid encodings, use \code{iconvlist()}
+#'
 #' @keywords internal
 
 b_wincred_set_with_raw_value <- function(self, private, service,
                                          username, password, keyring) {
+
   keyring <- keyring %||% private$keyring
   target <- b_wincred_target(keyring, service, username)
   if (is.null(keyring)) {

--- a/R/backend-wincred.R
+++ b/R/backend-wincred.R
@@ -303,6 +303,12 @@ b_wincred_set <- function(self, private, service, username, keyring) {
 
 b_wincred_set_with_value <- function(self, private, service,
                                      username, password, keyring) {
+  encoding <- get_encoding_opt()
+  if (encoding != 'auto') {
+    password = iconv(x = password, from = '', to = encoding, toRaw = TRUE)[[1]]
+  } else {
+    password = charToRaw(password)
+  }
   b_wincred_set_with_raw_value(self, private, service, username, password, keyring)
 }
 
@@ -336,12 +342,6 @@ b_wincred_set_with_raw_value <- function(self, private, service,
 
   keyring <- keyring %||% private$keyring
   target <- b_wincred_target(keyring, service, username)
-  encoding <- get_encoding_opt()
-  if (encoding != 'auto') {
-    password = iconv(x = password, from = '', to = encoding, toRaw = TRUE)[[1]]
-  } else {
-    password = charToRaw(password)
-  }
   if (is.null(keyring)) {
     b_wincred_i_set(target, password, username = username)
     return(invisible(self))

--- a/R/utils.R
+++ b/R/utils.R
@@ -42,34 +42,34 @@ URLencode <- function(URL) {
 }
 
 get_encoding_opt <- function() {
-  opt_encoding <- tolower(getOption('keyring.encoding.windows'))
-  if (length(opt_encoding) == 0) opt_encoding = 'auto'
+  opt_encoding <- tolower(getOption("keyring.encoding.windows"))
+  if (length(opt_encoding) == 0) opt_encoding <- "auto"
   env_encoding <- tolower(Sys.getenv("KEYRING_ENCODING_WINDOWS"))
-  if (env_encoding == '') env_encoding = 'auto'
+  if (env_encoding == "") env_encoding <- "auto"
   # Handle differing values if one or the other is not auto -- stop in this case
-  if (opt_encoding != env_encoding & !(opt_encoding == 'auto' | env_encoding == 'auto')) {
+  if (opt_encoding != env_encoding & !(opt_encoding == "auto" | env_encoding == "auto")) {
     message(sprintf("Sys.getenv('KEYRING_ENCODING_WINDOWS'):\t'%s'", env_encoding))
     message(sprintf("getOption(keyring.encoding.windows):\t'%s'", opt_encoding))
     stop("Mismatch in keyring encoding settings; value set with both an environment variable and R option.\nChange environment variable with Sys.setenv('KEYRING_ENCODING_WINDOWS' = 'encoding_type'),\nand R option with options(keyring.encoding.windows = 'encoding_type') to match.")
   }
   # If one and only one is auto, then one of these was set deliberately; respect this
-  if (xor(opt_encoding == 'auto', env_encoding == 'auto')) {
+  if (xor(opt_encoding == "auto", env_encoding == "auto")) {
     # Encoding is whichever one that is not auto.
     encodings <- c(opt_encoding, env_encoding)
-    encoding  <- encodings[ encodings != 'auto' ]
+    encoding <- encodings[encodings != "auto"]
   }
   # If both the same:
   if (opt_encoding == env_encoding) {
     # And they're auto, then auto
-    if (opt_encoding == 'auto') {
-      encoding = 'auto'
+    if (opt_encoding == "auto") {
+      encoding <- "auto"
     } else {
       # Otherwise, the encoding is either one
-      encoding = opt_encoding
+      encoding <- opt_encoding
     }
   }
   # Confirm valid encoding. Suggest closest match if not found.
-  if (encoding != 'auto' & !(encoding %in% tolower(iconvlist()))) {
+  if (encoding != "auto" & !(encoding %in% tolower(iconvlist()))) {
     closest_match <- iconvlist()[
       which.min(adist(encoding, tolower(iconvlist())))
     ]

--- a/man/b_wincred_get.Rd
+++ b/man/b_wincred_get.Rd
@@ -17,7 +17,11 @@ b_wincred_get(self, private, service, username, keyring)
 \item If locked, then unlock it.
 \item Get the AES key from the keyring.
 \item Decrypt the key with the AES key.
-}}
+}
+
+Additionally, users may specify an encoding to use when converting the
+password from a byte-string, for compatibility with other software such as
+python's keyring package. This is done via an option, or an environment variable.}
 
 \item{backend}{Backend object.}
 }

--- a/man/b_wincred_set_with_raw_value.Rd
+++ b/man/b_wincred_set_with_raw_value.Rd
@@ -21,7 +21,16 @@ b_wincred_set_with_raw_value(self, private, service, username, password,
 \item If yes, check if it is locked.
 \item If yes, unlock it.
 \item Encrypt the key with the AES key, and store it.
-}}
+}
+
+If required, an encoding can be specified using either an R option
+(\code{keyring.encoding.windows}) or environment variable
+(\code{KEYRING_ENCODING_WINDOWS}). To set, use one of:
+
+\code{options(keyring.encoding.windows = 'encoding-type')}
+\code{Sys.setenv("KEYRING_ENCODING_WINDOWS" = 'encoding-type')}
+
+For a list of valid encodings, use \code{iconvlist()}}
 }
 \description{
 Set a key on a Wincred keyring

--- a/man/key_get.Rd
+++ b/man/key_get.Rd
@@ -76,8 +76,8 @@ vector.
 service (if \code{service} is not \code{NULL}).
 \subsection{Encoding}{
 
-If required, an encoding can be specified using either an R option
-(\code{keyring.encoding.windows}) or environment variable
+On Windows, if required, an encoding can be specified using either an R
+option (\code{keyring.encoding.windows}) or environment variable
 (\code{KEYRING_ENCODING_WINDOWS}). These will be applied when both getting
 and setting keys. To set, use one of:
 

--- a/man/key_get.Rd
+++ b/man/key_get.Rd
@@ -92,8 +92,14 @@ To reset these values, restart your R session or use:
 \code{Sys.setenv("KEYRING_ENCODING_WINDOWS" = '')}
 
 This is reserved primarily for compatibility with keys set with other
-software, such as Python's implementation of keyring. For a list of valid
-encodings, use \code{iconvlist()}.
+software, such as Python's implementation of keyring. For a list of
+encodings, use \code{iconvlist()}, although it should be noted that not
+\emph{every} encoding can be properly converted, even for trivial cases. These may
+include CP-GR, CP-IS, cp1025, CP1125, CP1133, CP154, CP367, CP819, CP853,
+CSPTCP154, CYRILLIC-ASIAN, EUC-CN, EUCCN, hz-gb-2312, IBM-CP1133,
+iso-2022-kr, iso2022-kr, PT154, PTCP154, x-cp50227, x-Europa, x-iscii-as,
+x-iscii-be, x-iscii-de, x-iscii-gu, x-iscii-ka, x-iscii-ma, x-iscii-or,
+x-iscii-pa, x-iscii-ta, and x-iscii-te.
 }
 }
 \examples{

--- a/man/key_get.Rd
+++ b/man/key_get.Rd
@@ -74,6 +74,27 @@ vector.
 
 \code{key_list} lists all keys of a keyring, or the keys for a certain
 service (if \code{service} is not \code{NULL}).
+\subsection{Encoding}{
+
+If required, an encoding can be specified using either an R option
+(\code{keyring.encoding.windows}) or environment variable
+(\code{KEYRING_ENCODING_WINDOWS}). These will be applied when both getting
+and setting keys. To set, use one of:
+
+\code{options(keyring.encoding.windows = 'encoding-type')}
+
+\code{Sys.setenv("KEYRING_ENCODING_WINDOWS" = 'encoding-type')}
+
+To reset these values, restart your R session or use:
+
+\code{options(keyring.encoding.windows = NULL)}
+
+\code{Sys.setenv("KEYRING_ENCODING_WINDOWS" = '')}
+
+This is reserved primarily for compatibility with keys set with other
+software, such as Python's implementation of keyring. For a list of valid
+encodings, use \code{iconvlist()}.
+}
 }
 \examples{
 # These examples use the default keyring, and they are interactive,

--- a/tests/conda_envs/keyring37.yml
+++ b/tests/conda_envs/keyring37.yml
@@ -1,4 +1,4 @@
-name: keyring
+name: keyring37
 channels:
   - defaults
 dependencies:

--- a/tests/testthat/test-encoding.R
+++ b/tests/testthat/test-encoding.R
@@ -71,9 +71,9 @@ test_that("Having two different encodings set between opt and env return error",
 test_that("Set key with UTF-16LE encoding", {
   skip_if_not_win()
   skip_on_cran()
-  SERVICE = random_service()
-  USER    = random_username()
-  PASS    = random_password()
+  SERVICE <- random_service()
+  USER <- random_username()
+  PASS <- random_password()
   # Now, set a key with UTF-16LE encoding using new options
   Sys.setenv("KEYRING_ENCODING_WINDOWS" = "utf-16le")
   keyring::key_set_with_value(service = SERVICE, username = USER, password = PASS)
@@ -96,7 +96,7 @@ test_that("Set key with UTF-16LE encoding plus a keyring", {
   list <- kb$list()
   expect_equal(nrow(list), 0)
 
-  service  <- "testService"
+  service <- "testService"
   username <- "testUser"
   password <- random_password()
 

--- a/tests/testthat/test-encoding.R
+++ b/tests/testthat/test-encoding.R
@@ -110,3 +110,38 @@ test_that("Set key with UTF-16LE encoding plus a keyring", {
   expect_false(keyring %in% kb$keyring_list()$keyring)
   Sys.setenv("KEYRING_ENCODING_WINDOWS" = "")
 })
+
+test_that("Test all encodings") {
+  test_encoding = function(encoding) {
+    skip_if_not_win()
+    # skip_on_cran()
+    SERVICE <- "testService"
+    USER <- "testUser"
+    PASS <- random_password()
+    # Now, set a key with UTF-16LE encoding using new options
+    Sys.setenv("KEYRING_ENCODING_WINDOWS" = encoding)
+    keyring::key_set_with_value(service = SERVICE, username = USER, password = PASS)
+    # Get the password
+    expect_equal(keyring::key_get(service = SERVICE, username = USER), PASS)
+    # Show that it is UTF-16LE
+    raw_password <- keyring:::b_wincred_i_get(target = paste0(":", SERVICE, ":", USER))
+    expect_equal(iconv(list(raw_password), from = encoding, to = ""), PASS)
+    Sys.setenv("KEYRING_ENCODING_WINDOWS" = "")
+    key_delete(service = SERVICE, username = USER)
+  }
+
+  if (interactive()) {
+    n = length(iconvlist())
+    bad = 0
+    bad_encodings = c(character(0))
+    for (e in iconvlist()) {
+      print(e)
+      res = try(test_encoding(e))
+      if (inherits(res, 'try-error')) {
+        bad = bad + 1
+        bad_encodings = c(bad_encodings, e)
+      }
+    }
+    cat(100 * bad / n, "% encodings (", bad, "out of", n, ") not compatible")
+  }
+}

--- a/tests/testthat/test-encoding.R
+++ b/tests/testthat/test-encoding.R
@@ -71,11 +71,8 @@ test_that("Having two different encodings set between opt and env return error",
 test_that("Set key with UTF-16LE encoding", {
   skip_if_not_win()
   skip_on_cran()
-  kb = backend_wincred$new()
-  keyring = random_keyring()
   # Now, set a key with UTF-16LE encoding using new options
   Sys.setenv("KEYRING_ENCODING_WINDOWS" = 'utf-16le')
-  keyring <- random_keyring()
   keyring::key_set_with_value(service = "testEncoding", username = "testUser", password = "test123")
   # Get the password
   expect_equal(keyring::key_get(service = "testEncoding", username = "testUser"), 'test123')

--- a/tests/testthat/test-encoding.R
+++ b/tests/testthat/test-encoding.R
@@ -111,7 +111,7 @@ test_that("Set key with UTF-16LE encoding plus a keyring", {
   Sys.setenv("KEYRING_ENCODING_WINDOWS" = "")
 })
 
-test_that("Test all encodings") {
+test_that("Test all encodings", {
   test_encoding = function(encoding) {
     skip_if_not_win()
     # skip_on_cran()
@@ -143,5 +143,6 @@ test_that("Test all encodings") {
       }
     }
     cat(100 * bad / n, "% encodings (", bad, "out of", n, ") not compatible")
+    Sys.setenv("KEYRING_ENCODING_WINDOWS" = "")
   }
-}
+})

--- a/tests/testthat/test-encoding.R
+++ b/tests/testthat/test-encoding.R
@@ -71,13 +71,17 @@ test_that("Having two different encodings set between opt and env return error",
 test_that("Set key with UTF-16LE encoding", {
   skip_if_not_win()
   skip_on_cran()
+  SERVICE = random_service()
+  USER    = random_username()
+  PASS    = random_password()
   # Now, set a key with UTF-16LE encoding using new options
   Sys.setenv("KEYRING_ENCODING_WINDOWS" = "utf-16le")
-  keyring::key_set_with_value(service = "testEncoding", username = "testUser", password = "test123")
+  keyring::key_set_with_value(service = SERVICE, username = USER, password = PASS)
   # Get the password
-  expect_equal(keyring::key_get(service = "testEncoding", username = "testUser"), "test123")
+  expect_equal(keyring::key_get(service = SERVICE, username = USER), PASS)
   # Show that it is UTF-16LE
-  raw_password <- keyring:::b_wincred_i_get(target = ":testEncoding:testUser")
-  expect_equal(iconv(list(raw_password), from = "UTF-16LE", to = ""), "test123")
+  raw_password <- keyring:::b_wincred_i_get(target = paste0(":", SERVICE, ":", USER))
+  expect_equal(iconv(list(raw_password), from = "UTF-16LE", to = ""), PASS)
   Sys.setenv("KEYRING_ENCODING_WINDOWS" = "")
+  key_delete(service = SERVICE, username = USER)
 })

--- a/tests/testthat/test-encoding.R
+++ b/tests/testthat/test-encoding.R
@@ -85,3 +85,28 @@ test_that("Set key with UTF-16LE encoding", {
   Sys.setenv("KEYRING_ENCODING_WINDOWS" = "")
   key_delete(service = SERVICE, username = USER)
 })
+
+test_that("Set key with UTF-16LE encoding plus a keyring", {
+  Sys.setenv("KEYRING_ENCODING_WINDOWS" = "utf-16le")
+  keyring <- random_keyring()
+  kb <- backend_wincred$new(keyring = keyring)
+  kb$.__enclos_env__$private$keyring_create_direct(keyring, "secret123!")
+  expect_true(keyring %in% kb$keyring_list()$keyring)
+
+  list <- kb$list()
+  expect_equal(nrow(list), 0)
+
+  service  <- "testService"
+  username <- "testUser"
+  password <- random_password()
+
+  expect_silent(
+    kb$set_with_value(service, username, password)
+  )
+
+  expect_equal(kb$get(service, username), password)
+  expect_silent(kb$delete(service, username))
+  expect_silent(kb$keyring_delete(keyring = keyring))
+  expect_false(keyring %in% kb$keyring_list()$keyring)
+  Sys.setenv("KEYRING_ENCODING_WINDOWS" = "")
+})

--- a/tests/testthat/test-encoding.R
+++ b/tests/testthat/test-encoding.R
@@ -1,0 +1,86 @@
+context("Testing encoding retrieval function")
+
+test_that("No option/env var set returns auto", {
+  skip_if_not_win()
+  skip_on_cran()
+  encoding = get_encoding_opt()
+  expect_equal(encoding, 'auto')
+})
+
+test_that("Option encoding set and env unset returns option encoding", {
+  skip_if_not_win()
+  skip_on_cran()
+  options(keyring.encoding.windows = 'utf-16le')
+  encoding = get_encoding_opt()
+  expect_equal(encoding, 'utf-16le')
+  options(keyring.encoding.windows = NULL)
+})
+
+test_that("Option encoding unset and env set returns env encoding", {
+  skip_if_not_win()
+  skip_on_cran()
+  Sys.setenv("KEYRING_ENCODING_WINDOWS" = 'utf-8')
+  encoding = get_encoding_opt()
+  expect_equal(encoding, 'utf-8')
+  Sys.setenv("KEYRING_ENCODING_WINDOWS" = '')
+})
+
+test_that("Option encoding set and env var set and EQUAL returns expected value", {
+  skip_if_not_win()
+  skip_on_cran()
+  options(keyring.encoding.windows = 'utf-16le')
+  Sys.setenv("KEYRING_ENCODING_WINDOWS" = 'utf-16le')
+  encoding = get_encoding_opt()
+  expect_equal(encoding, 'utf-16le')
+  options(keyring.encoding.windows = NULL)
+  Sys.setenv("KEYRING_ENCODING_WINDOWS" = '')
+})
+
+test_that("Invalid encoding (not in iconvlist) returns error", {
+  skip_if_not_win()
+  skip_on_cran()
+  options(keyring.encoding.windows = 'Omicron Persei 8')
+  Sys.setenv("KEYRING_ENCODING_WINDOWS" = 'Omicron Persei 8')
+  expect_error(get_encoding_opt())
+  options(keyring.encoding.windows = NULL)
+  Sys.setenv("KEYRING_ENCODING_WINDOWS" = '')
+})
+
+test_that("iconv suggestion works as expected", {
+  skip_if_not_win()
+  skip_on_cran()
+  options(keyring.encoding.windows = 'utf-16lp')
+  expect_message(
+    object = expect_error(get_encoding_opt()),
+    regexp = "Encoding not found in iconvlist(). Did you mean UTF-16LE?",
+    fixed = TRUE
+  )
+  options(keyring.encoding.windows = NULL)
+})
+
+test_that("Having two different encodings set between opt and env return error", {
+  skip_if_not_win()
+  skip_on_cran()
+  options(keyring.encoding.windows = 'x_Chinese-Eten')
+  Sys.setenv("KEYRING_ENCODING_WINDOWS" = 'latin9')
+  expect_error(get_encoding_opt())
+  options(keyring.encoding.windows = NULL)
+  Sys.setenv("KEYRING_ENCODING_WINDOWS" = '')
+})
+
+test_that("Set key with UTF-16LE encoding", {
+  skip_if_not_win()
+  skip_on_cran()
+  kb = backend_wincred$new()
+  keyring = random_keyring()
+  # Now, set a key with UTF-16LE encoding using new options
+  Sys.setenv("KEYRING_ENCODING_WINDOWS" = 'utf-16le')
+  keyring <- random_keyring()
+  keyring::key_set_with_value(service = "testEncoding", username = "testUser", password = "test123")
+  # Get the password
+  expect_equal(keyring::key_get(service = "testEncoding", username = "testUser"), 'test123')
+  # Show that it is UTF-16LE
+  raw_password = keyring:::b_wincred_i_get(target = ":testEncoding:testUser")
+  expect_equal(iconv(list(raw_password), from = "UTF-16LE", to = ''), 'test123')
+  Sys.setenv("KEYRING_ENCODING_WINDOWS" = '')
+})

--- a/tests/testthat/test-encoding.R
+++ b/tests/testthat/test-encoding.R
@@ -3,53 +3,53 @@ context("Testing encoding retrieval function")
 test_that("No option/env var set returns auto", {
   skip_if_not_win()
   skip_on_cran()
-  encoding = get_encoding_opt()
-  expect_equal(encoding, 'auto')
+  encoding <- get_encoding_opt()
+  expect_equal(encoding, "auto")
 })
 
 test_that("Option encoding set and env unset returns option encoding", {
   skip_if_not_win()
   skip_on_cran()
-  options(keyring.encoding.windows = 'utf-16le')
-  encoding = get_encoding_opt()
-  expect_equal(encoding, 'utf-16le')
+  options(keyring.encoding.windows = "utf-16le")
+  encoding <- get_encoding_opt()
+  expect_equal(encoding, "utf-16le")
   options(keyring.encoding.windows = NULL)
 })
 
 test_that("Option encoding unset and env set returns env encoding", {
   skip_if_not_win()
   skip_on_cran()
-  Sys.setenv("KEYRING_ENCODING_WINDOWS" = 'utf-8')
-  encoding = get_encoding_opt()
-  expect_equal(encoding, 'utf-8')
-  Sys.setenv("KEYRING_ENCODING_WINDOWS" = '')
+  Sys.setenv("KEYRING_ENCODING_WINDOWS" = "utf-8")
+  encoding <- get_encoding_opt()
+  expect_equal(encoding, "utf-8")
+  Sys.setenv("KEYRING_ENCODING_WINDOWS" = "")
 })
 
 test_that("Option encoding set and env var set and EQUAL returns expected value", {
   skip_if_not_win()
   skip_on_cran()
-  options(keyring.encoding.windows = 'utf-16le')
-  Sys.setenv("KEYRING_ENCODING_WINDOWS" = 'utf-16le')
-  encoding = get_encoding_opt()
-  expect_equal(encoding, 'utf-16le')
+  options(keyring.encoding.windows = "utf-16le")
+  Sys.setenv("KEYRING_ENCODING_WINDOWS" = "utf-16le")
+  encoding <- get_encoding_opt()
+  expect_equal(encoding, "utf-16le")
   options(keyring.encoding.windows = NULL)
-  Sys.setenv("KEYRING_ENCODING_WINDOWS" = '')
+  Sys.setenv("KEYRING_ENCODING_WINDOWS" = "")
 })
 
 test_that("Invalid encoding (not in iconvlist) returns error", {
   skip_if_not_win()
   skip_on_cran()
-  options(keyring.encoding.windows = 'Omicron Persei 8')
-  Sys.setenv("KEYRING_ENCODING_WINDOWS" = 'Omicron Persei 8')
+  options(keyring.encoding.windows = "Omicron Persei 8")
+  Sys.setenv("KEYRING_ENCODING_WINDOWS" = "Omicron Persei 8")
   expect_error(get_encoding_opt())
   options(keyring.encoding.windows = NULL)
-  Sys.setenv("KEYRING_ENCODING_WINDOWS" = '')
+  Sys.setenv("KEYRING_ENCODING_WINDOWS" = "")
 })
 
 test_that("iconv suggestion works as expected", {
   skip_if_not_win()
   skip_on_cran()
-  options(keyring.encoding.windows = 'utf-16lp')
+  options(keyring.encoding.windows = "utf-16lp")
   expect_message(
     object = expect_error(get_encoding_opt()),
     regexp = "Encoding not found in iconvlist(). Did you mean UTF-16LE?",
@@ -61,23 +61,23 @@ test_that("iconv suggestion works as expected", {
 test_that("Having two different encodings set between opt and env return error", {
   skip_if_not_win()
   skip_on_cran()
-  options(keyring.encoding.windows = 'x_Chinese-Eten')
-  Sys.setenv("KEYRING_ENCODING_WINDOWS" = 'latin9')
+  options(keyring.encoding.windows = "x_Chinese-Eten")
+  Sys.setenv("KEYRING_ENCODING_WINDOWS" = "latin9")
   expect_error(get_encoding_opt())
   options(keyring.encoding.windows = NULL)
-  Sys.setenv("KEYRING_ENCODING_WINDOWS" = '')
+  Sys.setenv("KEYRING_ENCODING_WINDOWS" = "")
 })
 
 test_that("Set key with UTF-16LE encoding", {
   skip_if_not_win()
   skip_on_cran()
   # Now, set a key with UTF-16LE encoding using new options
-  Sys.setenv("KEYRING_ENCODING_WINDOWS" = 'utf-16le')
+  Sys.setenv("KEYRING_ENCODING_WINDOWS" = "utf-16le")
   keyring::key_set_with_value(service = "testEncoding", username = "testUser", password = "test123")
   # Get the password
-  expect_equal(keyring::key_get(service = "testEncoding", username = "testUser"), 'test123')
+  expect_equal(keyring::key_get(service = "testEncoding", username = "testUser"), "test123")
   # Show that it is UTF-16LE
-  raw_password = keyring:::b_wincred_i_get(target = ":testEncoding:testUser")
-  expect_equal(iconv(list(raw_password), from = "UTF-16LE", to = ''), 'test123')
-  Sys.setenv("KEYRING_ENCODING_WINDOWS" = '')
+  raw_password <- keyring:::b_wincred_i_get(target = ":testEncoding:testUser")
+  expect_equal(iconv(list(raw_password), from = "UTF-16LE", to = ""), "test123")
+  Sys.setenv("KEYRING_ENCODING_WINDOWS" = "")
 })

--- a/tests/testthat/test-python-compatibility.R
+++ b/tests/testthat/test-python-compatibility.R
@@ -158,4 +158,11 @@ test_that("R can read from UTF-16LE encoded key set with R", {
   # R should also still be able to read from this.
 })
 
-key_delete(service = "testService", username = "testUser")
+# Clean up ---------------------------------------------------------------------
+try (
+  {
+    key_delete(service = "testService", username = "testUser")
+    pyring$delete_password(service_name = "testPython", username = "testUser")
+    pyring$delete_password(service_name = ":testPython:testUser", username = "testUser")
+  }
+)

--- a/tests/testthat/test-python-compatibility.R
+++ b/tests/testthat/test-python-compatibility.R
@@ -3,61 +3,10 @@
 library(reticulate)
 library(keyring)
 
-context("Testing encoding retrieval function")
+# Tests ------------------------------------------------------------------------
 
-test_that("No option/env var set returns auto", {
-  encoding = get_encoding_opt()
-  expect_equal(encoding, 'auto')
-})
-
-test_that("Option encoding set and env unset returns option encoding", {
-  options(keyring.encoding.windows = 'utf-16le')
-  encoding = get_encoding_opt()
-  expect_equal(encoding, 'utf-16le')
-  options(keyring.encoding.windows = NULL)
-})
-
-test_that("Option encoding unset and env set returns env encoding", {
-  Sys.setenv("KEYRING_ENCODING_WINDOWS" = 'utf-8')
-  encoding = get_encoding_opt()
-  expect_equal(encoding, 'utf-8')
-  Sys.setenv("KEYRING_ENCODING_WINDOWS" = '')
-})
-
-test_that("Option encoding set and env var set and EQUAL returns expected value", {
-  options(keyring.encoding.windows = 'utf-16le')
-  Sys.setenv("KEYRING_ENCODING_WINDOWS" = 'utf-16le')
-  encoding = get_encoding_opt()
-  expect_equal(encoding, 'utf-16le')
-  options(keyring.encoding.windows = NULL)
-  Sys.setenv("KEYRING_ENCODING_WINDOWS" = '')
-})
-
-test_that("Invalid encoding (not in iconvlist) returns error", {
-  options(keyring.encoding.windows = 'Omicron Persei 8')
-  Sys.setenv("KEYRING_ENCODING_WINDOWS" = 'Omicron Persei 8')
-  expect_error(get_encoding_opt())
-  options(keyring.encoding.windows = NULL)
-  Sys.setenv("KEYRING_ENCODING_WINDOWS" = '')
-})
-
-test_that("iconv suggestion works as expected", {
-  options(keyring.encoding.windows = 'utf-16lp')
-  expect_message(
-    object = expect_error(get_encoding_opt()),
-    regexp = "Encoding not found in iconvlist(). Did you mean UTF-16LE?",
-    fixed = TRUE
-  )
-  options(keyring.encoding.windows = NULL)
-})
-
-test_that("Having two different encodings set between opt and env return error", {
-  options(keyring.encoding.windows = 'x_Chinese-Eten')
-  Sys.setenv("KEYRING_ENCODING_WINDOWS" = 'latin9')
-  expect_error(get_encoding_opt())
-  options(keyring.encoding.windows = NULL)
-  Sys.setenv("KEYRING_ENCODING_WINDOWS" = '')
-})
+# For now the encoding functionality and cross-compatiblity with Python is only
+# supported on Windows!
 
 context("Testing compatibility with python keyring package")
 

--- a/tests/testthat/test-python-compatibility.R
+++ b/tests/testthat/test-python-compatibility.R
@@ -10,7 +10,7 @@ library(keyring)
 
 context("Testing compatibility with python keyring package")
 
-reticulate::use_condaenv('keyring', required = TRUE)
+reticulate::use_condaenv('keyring37', required = TRUE)
 pyring <- reticulate::import('keyring')
 
 test_that("Setting key with R cannot be read using python under default settings (encoding mismatches)", {

--- a/tests/testthat/test-python-compatibility.R
+++ b/tests/testthat/test-python-compatibility.R
@@ -14,6 +14,8 @@ reticulate::use_condaenv('keyring37', required = TRUE)
 pyring <- reticulate::import('keyring')
 
 test_that("Setting key with R cannot be read using python under default settings (encoding mismatches)", {
+  skip_if_not_win()
+  skip_on_cran()
   # Set with R, default settings
   keyring::key_set_with_value(service = "testService", username = "testUser", password = "test123")
   keyring::key_get(service = "testService", username = "testUser")
@@ -23,12 +25,16 @@ test_that("Setting key with R cannot be read using python under default settings
 })
 
 test_that("Setting key with python can be read using R", {
+  skip_if_not_win()
+  skip_on_cran()
   # Python sets keys UTF-16LE encoded by default, but the R keyring package can handle that.
   pyring$set_password(":testPython:testUser", "testUser", "test123")
   expect_equal(keyring::key_get(service = "testPython", username = "testUser"), 'test123')
 })
 
 test_that("Reading UTF-16LE with encoding specified as UTF-8 will fail", {
+  skip_if_not_win()
+  skip_on_cran()
   # This shows that the encoding options are working, and being applied. The
   # repeated lines below use various casing to ensure that casing doesn't
   # matter.
@@ -61,6 +67,8 @@ test_that("Reading UTF-16LE with encoding specified as UTF-8 will fail", {
 })
 
 test_that("Reading UTF-16LE with encoding specified as UTF-16LE will work", {
+  skip_if_not_win()
+  skip_on_cran()
   # This shows that the encoding options are working, and being applied. The
   # repeated lines below use various casing to ensure that casing doesn't
   # matter.
@@ -90,16 +98,22 @@ test_that("Reading UTF-16LE with encoding specified as UTF-16LE will work", {
 })
 
 test_that("Any arbitrary key set by python can be read using R, not necessarily of the same form of this keyring API", {
+  skip_if_not_win()
+  skip_on_cran()
   pyring$set_password("testPython", "testUser", "test123")
   pass <- keyring:::b_wincred_i_get(target = "testPython")
   expect_equal(iconv(list(pass), from = 'UTF-16LE', to = ''), "test123")
 })
 
 test_that("Set key with UTF-16LE encoding", {
+  skip_if_not_win()
+  skip_on_cran()
   # Now, set a key with UTF-16LE encoding using new options
 })
 
 test_that("Python can read from UTF-16LE encoded key set with R", {
+  skip_if_not_win()
+  skip_on_cran()
   # Python should be able to read from this.
 })
 

--- a/tests/testthat/test-python-compatibility.R
+++ b/tests/testthat/test-python-compatibility.R
@@ -10,12 +10,28 @@ library(keyring)
 
 context("Testing compatibility with python keyring package")
 
-reticulate::use_condaenv('keyring37', required = TRUE)
-pyring <- reticulate::import('keyring')
+KEYRING_ENV = 'keyring37'
+ENVS = reticulate::conda_list()$name
+
+skip_if_no_conda = function() {
+  if (! reticulate::py_available()) {
+    skip("Python not available")
+  }
+  if (!(KEYRING_ENV %in% ENVS)) {
+    skip("Conda environment not available")
+  }
+  invisible(TRUE)
+}
+
+if (KEYRING_ENV %in% ENVS) {
+  reticulate::use_condaenv('keyring37', required = TRUE)
+  pyring <- reticulate::import('keyring')
+}
 
 test_that("Setting key with R cannot be read using python under default settings (encoding mismatches)", {
   skip_if_not_win()
   skip_on_cran()
+  skip_if_no_conda()
   # Set with R, default settings
   keyring::key_set_with_value(service = "testService", username = "testUser", password = "test123")
   keyring::key_get(service = "testService", username = "testUser")
@@ -27,6 +43,7 @@ test_that("Setting key with R cannot be read using python under default settings
 test_that("Setting key with python can be read using R", {
   skip_if_not_win()
   skip_on_cran()
+  skip_if_no_conda()
   # Python sets keys UTF-16LE encoded by default, but the R keyring package can handle that.
   pyring$set_password(":testPython:testUser", "testUser", "test123")
   expect_equal(keyring::key_get(service = "testPython", username = "testUser"), 'test123')
@@ -35,6 +52,7 @@ test_that("Setting key with python can be read using R", {
 test_that("Reading UTF-16LE with encoding specified as UTF-8 will fail", {
   skip_if_not_win()
   skip_on_cran()
+  skip_if_no_conda()
   # This shows that the encoding options are working, and being applied. The
   # repeated lines below use various casing to ensure that casing doesn't
   # matter.
@@ -69,6 +87,7 @@ test_that("Reading UTF-16LE with encoding specified as UTF-8 will fail", {
 test_that("Reading UTF-16LE with encoding specified as UTF-16LE will work", {
   skip_if_not_win()
   skip_on_cran()
+  skip_if_no_conda()
   # This shows that the encoding options are working, and being applied. The
   # repeated lines below use various casing to ensure that casing doesn't
   # matter.
@@ -100,6 +119,7 @@ test_that("Reading UTF-16LE with encoding specified as UTF-16LE will work", {
 test_that("Any arbitrary key set by python can be read using R, not necessarily of the same form of this keyring API", {
   skip_if_not_win()
   skip_on_cran()
+  skip_if_no_conda()
   pyring$set_password("testPython", "testUser", "test123")
   pass <- keyring:::b_wincred_i_get(target = "testPython")
   expect_equal(iconv(list(pass), from = 'UTF-16LE', to = ''), "test123")
@@ -108,6 +128,7 @@ test_that("Any arbitrary key set by python can be read using R, not necessarily 
 test_that("Python can read from UTF-16LE encoded key set with R", {
   skip_if_not_win()
   skip_on_cran()
+  skip_if_no_conda()
   Sys.setenv("KEYRING_ENCODING_WINDOWS" = 'utf-16le')
   keyring::key_set_with_value(service = "testEncoding", username = "testUser", password = "test123")
   # Python should be able to read from this.
@@ -115,21 +136,27 @@ test_that("Python can read from UTF-16LE encoded key set with R", {
   Sys.setenv("KEYRING_ENCODING_WINDOWS" = '')
 })
 
-test_that("Python can read from UTF-16LE encoded key set with R", {
-  skip_if_not_win()
-  skip_on_cran()
-  # Python should be able to read from this.
-})
-
-test_that("R can read from UTF-16LE encoded key set with R", {
-  # R should also still be able to read from this.
-})
+if (interactive()) {
+  test_that("Password set in R using a keyring", {
+    skip_if_not_win()
+    skip_on_cran()
+    skip_if_no_conda()
+    Sys.setenv("KEYRING_ENCODING_WINDOWS" = 'utf-16le')
+    keyring::keyring_create("testKeyring")
+    keyring::key_set_with_value(service = "testEncoding", username = "testUser", password = "test123", keyring = 'testKeyring')
+    expect_equal(keyring::key_get(service = "testEncoding", username = "testUser", keyring = 'testKeyring'), 'test123')
+    Sys.setenv("KEYRING_ENCODING_WINDOWS" = '')
+  })
+}
 
 # Clean up ---------------------------------------------------------------------
 try (
   {
     key_delete(service = "testService", username = "testUser")
+    key_delete(service = "testEncoding", username = "testUser")
+    keyring:::b_wincred_i_delete()
     pyring$delete_password(service_name = "testPython", username = "testUser")
     pyring$delete_password(service_name = ":testPython:testUser", username = "testUser")
-  }
+  },
+  silent = TRUE
 )

--- a/tests/testthat/test-python-compatibility.R
+++ b/tests/testthat/test-python-compatibility.R
@@ -10,11 +10,11 @@ library(keyring)
 
 context("Testing compatibility with python keyring package")
 
-KEYRING_ENV = 'keyring37'
-ENVS = reticulate::conda_list()$name
+KEYRING_ENV <- "keyring37"
+ENVS <- reticulate::conda_list()$name
 
-skip_if_no_conda = function() {
-  if (! reticulate::py_available()) {
+skip_if_no_conda <- function() {
+  if (!reticulate::py_available()) {
     skip("Python not available")
   }
   if (!(KEYRING_ENV %in% ENVS)) {
@@ -24,8 +24,8 @@ skip_if_no_conda = function() {
 }
 
 if (KEYRING_ENV %in% ENVS) {
-  reticulate::use_condaenv('keyring37', required = TRUE)
-  pyring <- reticulate::import('keyring')
+  reticulate::use_condaenv("keyring37", required = TRUE)
+  pyring <- reticulate::import("keyring")
 }
 
 test_that("Setting key with R cannot be read using python under default settings (encoding mismatches)", {
@@ -46,7 +46,7 @@ test_that("Setting key with python can be read using R", {
   skip_if_no_conda()
   # Python sets keys UTF-16LE encoded by default, but the R keyring package can handle that.
   pyring$set_password(":testPython:testUser", "testUser", "test123")
-  expect_equal(keyring::key_get(service = "testPython", username = "testUser"), 'test123')
+  expect_equal(keyring::key_get(service = "testPython", username = "testUser"), "test123")
 })
 
 test_that("Reading UTF-16LE with encoding specified as UTF-8 will fail", {
@@ -56,7 +56,7 @@ test_that("Reading UTF-16LE with encoding specified as UTF-8 will fail", {
   # This shows that the encoding options are working, and being applied. The
   # repeated lines below use various casing to ensure that casing doesn't
   # matter.
-  encodings = c("UTF-8", "uTF-8", "UTf-8")
+  encodings <- c("UTF-8", "uTF-8", "UTf-8")
 
   test_env_encoding <- function(encoding) {
     Sys.setenv("KEYRING_ENCODING_WINDOWS" = encoding)
@@ -81,7 +81,6 @@ test_that("Reading UTF-16LE with encoding specified as UTF-8 will fail", {
 
   # Reset
   options(keyring.encoding.windows = NULL)
-
 })
 
 test_that("Reading UTF-16LE with encoding specified as UTF-16LE will work", {
@@ -91,7 +90,7 @@ test_that("Reading UTF-16LE with encoding specified as UTF-16LE will work", {
   # This shows that the encoding options are working, and being applied. The
   # repeated lines below use various casing to ensure that casing doesn't
   # matter.
-  encodings = c("UTF-16LE", "uTF-16LE", "UTf16le", 'utf-16le')
+  encodings <- c("UTF-16LE", "uTF-16LE", "UTf16le", "utf-16le")
 
   test_env_encoding <- function(encoding) {
     Sys.setenv("KEYRING_ENCODING_WINDOWS" = encoding)
@@ -99,7 +98,7 @@ test_that("Reading UTF-16LE with encoding specified as UTF-16LE will work", {
   }
 
   for (e in encodings) {
-    expect_equal(test_env_encoding(e), 'test123')
+    expect_equal(test_env_encoding(e), "test123")
   }
 
   # Reset
@@ -111,9 +110,8 @@ test_that("Reading UTF-16LE with encoding specified as UTF-16LE will work", {
   }
 
   for (e in encodings) {
-    expect_equal(test_env_encoding(e), 'test123')
+    expect_equal(test_env_encoding(e), "test123")
   }
-
 })
 
 test_that("Any arbitrary key set by python can be read using R, not necessarily of the same form of this keyring API", {
@@ -122,18 +120,18 @@ test_that("Any arbitrary key set by python can be read using R, not necessarily 
   skip_if_no_conda()
   pyring$set_password("testPython", "testUser", "test123")
   pass <- keyring:::b_wincred_i_get(target = "testPython")
-  expect_equal(iconv(list(pass), from = 'UTF-16LE', to = ''), "test123")
+  expect_equal(iconv(list(pass), from = "UTF-16LE", to = ""), "test123")
 })
 
 test_that("Python can read from UTF-16LE encoded key set with R", {
   skip_if_not_win()
   skip_on_cran()
   skip_if_no_conda()
-  Sys.setenv("KEYRING_ENCODING_WINDOWS" = 'utf-16le')
+  Sys.setenv("KEYRING_ENCODING_WINDOWS" = "utf-16le")
   keyring::key_set_with_value(service = "testEncoding", username = "testUser", password = "test123")
   # Python should be able to read from this.
-  expect_equal(pyring$get_password(service_name = ":testEncoding:testUser", username = "testUser"), 'test123')
-  Sys.setenv("KEYRING_ENCODING_WINDOWS" = '')
+  expect_equal(pyring$get_password(service_name = ":testEncoding:testUser", username = "testUser"), "test123")
+  Sys.setenv("KEYRING_ENCODING_WINDOWS" = "")
 })
 
 if (interactive()) {
@@ -141,16 +139,16 @@ if (interactive()) {
     skip_if_not_win()
     skip_on_cran()
     skip_if_no_conda()
-    Sys.setenv("KEYRING_ENCODING_WINDOWS" = 'utf-16le')
+    Sys.setenv("KEYRING_ENCODING_WINDOWS" = "utf-16le")
     keyring::keyring_create("testKeyring")
-    keyring::key_set_with_value(service = "testEncoding", username = "testUser", password = "test123", keyring = 'testKeyring')
-    expect_equal(keyring::key_get(service = "testEncoding", username = "testUser", keyring = 'testKeyring'), 'test123')
-    Sys.setenv("KEYRING_ENCODING_WINDOWS" = '')
+    keyring::key_set_with_value(service = "testEncoding", username = "testUser", password = "test123", keyring = "testKeyring")
+    expect_equal(keyring::key_get(service = "testEncoding", username = "testUser", keyring = "testKeyring"), "test123")
+    Sys.setenv("KEYRING_ENCODING_WINDOWS" = "")
   })
 }
 
 # Clean up ---------------------------------------------------------------------
-try (
+try(
   {
     key_delete(service = "testService", username = "testUser")
     key_delete(service = "testEncoding", username = "testUser")

--- a/tests/testthat/test-python-compatibility.R
+++ b/tests/testthat/test-python-compatibility.R
@@ -105,10 +105,14 @@ test_that("Any arbitrary key set by python can be read using R, not necessarily 
   expect_equal(iconv(list(pass), from = 'UTF-16LE', to = ''), "test123")
 })
 
-test_that("Set key with UTF-16LE encoding", {
+test_that("Python can read from UTF-16LE encoded key set with R", {
   skip_if_not_win()
   skip_on_cran()
-  # Now, set a key with UTF-16LE encoding using new options
+  Sys.setenv("KEYRING_ENCODING_WINDOWS" = 'utf-16le')
+  keyring::key_set_with_value(service = "testEncoding", username = "testUser", password = "test123")
+  # Python should be able to read from this.
+  expect_equal(pyring$get_password(service_name = ":testEncoding:testUser", username = "testUser"), 'test123')
+  Sys.setenv("KEYRING_ENCODING_WINDOWS" = '')
 })
 
 test_that("Python can read from UTF-16LE encoded key set with R", {

--- a/tests/testthat/test-python-compatibility.R
+++ b/tests/testthat/test-python-compatibility.R
@@ -148,13 +148,9 @@ if (interactive()) {
 }
 
 # Clean up ---------------------------------------------------------------------
-try(
-  {
-    key_delete(service = "testService", username = "testUser")
-    key_delete(service = "testEncoding", username = "testUser")
-    keyring:::b_wincred_i_delete()
-    pyring$delete_password(service_name = "testPython", username = "testUser")
-    pyring$delete_password(service_name = ":testPython:testUser", username = "testUser")
-  },
-  silent = TRUE
-)
+{
+  key_delete(service = "testService", username = "testUser")
+  key_delete(service = "testEncoding", username = "testUser")
+  pyring$delete_password(service_name = "testPython", username = "testUser")
+  pyring$delete_password(service_name = ":testPython:testUser", username = "testUser")
+}


### PR DESCRIPTION
* Updates `b_wincred_set_with_value`, encoding the password with an encoding if and only if a) and option is set or b) and environment variable is set.
    * I did not want to modify the keyring API, and thus did not provide any additional arguments for encoding. This could be easily altered though, but all backends would have to accept this new argument.
* Adds separate python and encoding tests
    * Adds reticulate to suggests for tests
    * Conditionally run python test only if conda is set up properly, otherwise skip
* Updates help docs for encoding as it relates to setter functions and Windows. Notes encodings that don't work (problem specific to `iconv` itself).

All tests pass.